### PR TITLE
Add Metadata.blog_entries

### DIFF
--- a/truetone/models/content/metadata.py
+++ b/truetone/models/content/metadata.py
@@ -17,5 +17,13 @@ class ContentMetadata:
     def __markdown_files(directory):
         return sorted(glob.glob(f'{directory}/*.md'))
 
+    @staticmethod
+    def __is_blog_entry(entry):
+        return entry.is_blog_entry
+
     def __init__(self, metadata):
         self.metadata = metadata
+        self.blog_entries = self.__blog_entries()
+
+    def __blog_entries(self):
+        return list(filter(self.__is_blog_entry, self.metadata))

--- a/truetone/models/content/metadatum.py
+++ b/truetone/models/content/metadatum.py
@@ -16,3 +16,7 @@ class ContentMetadatum:
         self.slug = slug
         self.metadata = metadata
         self.title = metadata["title"]
+        self.is_blog_entry = self.__is_blog_entry()
+
+    def __is_blog_entry(self):
+        return self.metadata.get('blog_entry', False) is True

--- a/truetone/test/fixtures/content/entries/path-1.md
+++ b/truetone/test/fixtures/content/entries/path-1.md
@@ -1,0 +1,7 @@
+---
+author: Tony Thomas
+title: "Heading 1"
+blog_entry: true
+---
+
+# Heading 1

--- a/truetone/test/fixtures/content/entries/path-2.md
+++ b/truetone/test/fixtures/content/entries/path-2.md
@@ -1,0 +1,5 @@
+---
+author: Tony Thomas
+title: "Heading 1"
+blog_entry: false
+---

--- a/truetone/test/test_content_metadata.py
+++ b/truetone/test/test_content_metadata.py
@@ -17,3 +17,11 @@ def test_returns_metadata_when_given_a_directory_of_markdown_files():
     metadata = ContentMetadata.build(
             f'{cwd}/fixtures/content')
     assert metadata.metadata[0].title == 'Heading 1'
+
+
+def test_does_not_return_routes_when_frontmatter_has_blog_entry_false():
+    cwd = os.path.dirname(os.path.realpath(__file__))
+    metadata = ContentMetadata.build(
+            f'{cwd}/fixtures/content/entries')
+    assert len(metadata.blog_entries) == 1
+    assert metadata.blog_entries[0].is_blog_entry is True


### PR DESCRIPTION
Add an interface to retrieve markdown files only when the frontmatter
specifies `blog_entry: true`.

Closes #19